### PR TITLE
Harry Potter theme: name bar, owl cinematic, acceptance letter & z-index fixes

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Dev Server",
+      "runtimeExecutable": "/Users/bclehner/.nvm/versions/node/v18.16.0/bin/node",
+      "runtimeArgs": [
+        "/Users/bclehner/Documents/lehn0058/kid-test-game/.claude/worktrees/goofy-ptolemy-2623a8/node_modules/vite/bin/vite.js",
+        "--root",
+        "/Users/bclehner/Documents/lehn0058/kid-test-game/.claude/worktrees/goofy-ptolemy-2623a8"
+      ],
+      "port": 5173
+    },
+    {
+      "name": "Preview Server",
+      "runtimeExecutable": "/Users/bclehner/.nvm/versions/node/v18.16.0/bin/node",
+      "runtimeArgs": [
+        "/Users/bclehner/Documents/lehn0058/kid-test-game/.claude/worktrees/goofy-ptolemy-2623a8/node_modules/vite/bin/vite.js",
+        "preview",
+        "--root",
+        "/Users/bclehner/Documents/lehn0058/kid-test-game/.claude/worktrees/goofy-ptolemy-2623a8"
+      ],
+      "port": 4173
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,19 @@
-# Kid Test Game
+# Kid Test Game — Harry Potter Edition
 
-A kid-friendly character customisation game built with **Phaser 3** and **TypeScript**, bundled by **Vite**.
+A kid-friendly **Harry Potter–themed** character customisation and adventure game built with **Phaser 3** and **TypeScript**, bundled by **Vite**.
+
+## Theme Direction
+
+The game is evolving into a Harry Potter experience. The player creates their character on the select screen, then enters a living room where a magical story begins. Core narrative beats to build toward:
+
+- **Owl delivery** — 20 seconds after entering the living room, an owl crashes into the window. A letter (Hogwarts acceptance letter style) slips through and floats down to the character.
+- Future scenes: reading the letter, packing a trunk, traveling to Diagon Alley / Platform 9¾, arriving at Hogwarts.
+
+### Theming Guidelines
+- Colour palette: deep purples, golds, parchment tones, dark greens (Slytherin/Gryffindor accents).
+- UI text should feel hand-written / parchment-like where possible.
+- Sound design (future): owls hooting, wand whooshes, magical chimes.
+- Keep the character fully customisable — the player IS the protagonist.
 
 ## Tech Stack
 
@@ -45,8 +58,9 @@ tsconfig.json                    # TypeScript config (strict, bundler resolution
 
 1. **CharacterSelectScene** renders an 8-trait picker UI (two columns on desktop, single column on mobile). Selecting a trait calls `_drawCharacter()` which procedurally redraws the preview using `Phaser.GameObjects.Graphics`.
 2. `_onStartGame()` passes the selections record to **LivingRoomScene** via `scene.start()`.
-3. **LivingRoomScene** draws a procedural living room (wall, floor, window, TV, lamp, rug, couch) and places the sitting character on the couch. Arrow keys and an on-screen D-pad move the character within bounds.
-4. The Back button restores selections from the Phaser registry before restarting CharacterSelectScene.
+3. **LivingRoomScene** draws a procedural living room (wall, floor, window, TV on console, lamp, rug, couch) and places the sitting character on the couch. Arrow keys / D-pad move the character. Moving stands the character up; pressing **S** while stationary sits them back down.
+4. After 20 seconds in the living room, `_spawnOwl()` triggers: an owl flies in from the right, crashes into the window (camera shake), then `_spawnLetter()` sends a parchment letter floating down to the character's head.
+5. The Back button restores selections from the Phaser registry before restarting CharacterSelectScene.
 
 ## Responsive Layout
 
@@ -59,4 +73,5 @@ tsconfig.json                    # TypeScript config (strict, bundler resolution
 - `this.input.keyboard!` – keyboard plugin can be null if input is disabled; use `!` only inside `create()` after confirming input is active.
 - `Phaser.Display.Color.ValueToColor(hex).darken(n).color` converts a hex integer to a darkened hex integer.
 - Graphics are drawn once in `create()` (room, couch) and cleared/redrawn on trait changes (`_drawCharacter`).
-- To add a new trait: add an entry to `TRAITS`, add a color map if needed, and update the drawing logic in `_drawCharacter` / `_drawSittingCharacter`.
+- To add a new trait: add an entry to `TRAITS`, add a color map if needed, and update the drawing logic in `_drawCharacter` / `_drawSittingCharacter` / `_drawStandingCharacter`.
+- Z-depth in LivingRoomScene: background=0, couch back=1, character=5, accessories=6, couch front=8 (sitting) or 2 (standing), UI/cinematics=20+.

--- a/src/game.ts
+++ b/src/game.ts
@@ -28,6 +28,9 @@ const config: Phaser.Types.Core.GameConfig = {
   input: {
     activePointers: 3,
   },
+  dom: {
+    createContainer: true,
+  },
 };
 
 new Phaser.Game(config);

--- a/src/scenes/CharacterSelectScene.ts
+++ b/src/scenes/CharacterSelectScene.ts
@@ -94,7 +94,7 @@ export const BOTTOM_COLORS: Record<string, number> = {
 // Layout constants
 // ---------------------------------------------------------------------------
 const MOBILE_BREAKPOINT = 700;   // px – below this width use single-column layout
-const MOBILE_ROW_START_Y = 80;   // px – y position of first trait row on mobile
+const MOBILE_ROW_START_Y = 140;  // px – y position of first trait row on mobile (shifted to make room for name bar)
 const MOBILE_ROW_HEIGHT = 46;    // px – height per trait row on mobile
 const MOBILE_CHAR_HEIGHT = 310;  // px – approximate character drawing height
 const MOBILE_BTN_MARGIN = 60;    // px – bottom margin above the Start button
@@ -108,6 +108,7 @@ export class CharacterSelectScene extends Phaser.Scene {
   private _accessoryGraphics!: Phaser.GameObjects.Graphics;
   private _optionLabels: Phaser.GameObjects.Text[] = [];
   private _swatches: Record<string, Phaser.GameObjects.Rectangle> = {};
+  private _nameInput: Phaser.GameObjects.DOMElement | null = null;
 
   constructor() {
     super({ key: 'CharacterSelectScene' });
@@ -156,9 +157,43 @@ export class CharacterSelectScene extends Phaser.Scene {
     const H = this.scale.height;
     const isMobile = W < MOBILE_BREAKPOINT;
 
+    // ── Name bar ─────────────────────────────────────────────────────────────
+    this.add
+      .text(W / 2, 12, 'YOUR NAME', {
+        fontSize: '11px',
+        fontFamily: 'Arial',
+        color: '#aaaacc',
+        fontStyle: 'bold',
+        letterSpacing: 2,
+      })
+      .setOrigin(0.5);
+
+    const inputEl = document.createElement('input');
+    inputEl.type = 'text';
+    inputEl.placeholder = 'Enter your name…';
+    inputEl.maxLength = 20;
+    inputEl.value = localStorage.getItem('kid-game-player-name') ?? '';
+    inputEl.style.cssText = [
+      'width:220px',
+      'padding:5px 14px',
+      'border-radius:20px',
+      'border:2px solid #7a5fc0',
+      'background:#1a1a3e',
+      'color:#ffffff',
+      'font-size:16px',
+      'font-family:Arial,sans-serif',
+      'outline:none',
+      'text-align:center',
+      'box-sizing:border-box',
+    ].join(';');
+    inputEl.addEventListener('input', () => {
+      localStorage.setItem('kid-game-player-name', inputEl.value);
+    });
+    this._nameInput = this.add.dom(W / 2, 38, inputEl);
+
     // Title
     this.add
-      .text(W / 2, 28, 'Create Your Character', {
+      .text(W / 2, 82, 'Create Your Character', {
         fontSize: isMobile ? '22px' : '26px',
         fontFamily: 'Arial',
         color: '#ffffff',
@@ -168,7 +203,7 @@ export class CharacterSelectScene extends Phaser.Scene {
 
     // Subtitle
     this.add
-      .text(W / 2, 58, 'Customise 8 traits and watch your character update!', {
+      .text(W / 2, 112, 'Customise 8 traits and watch your character update!', {
         fontSize: '13px',
         fontFamily: 'Arial',
         color: '#aaaacc',
@@ -191,7 +226,7 @@ export class CharacterSelectScene extends Phaser.Scene {
       });
     } else {
       // Desktop: two columns of 4
-      const rowStartY = 100;
+      const rowStartY = 154;
       const rowHeight = 58;
       const colX = [20, 420]; // left / right column x
 
@@ -543,6 +578,11 @@ export class CharacterSelectScene extends Phaser.Scene {
   // Start button handler
   // -------------------------------------------------------------------------
   private _onStartGame(): void {
-    this.scene.start('LivingRoomScene', { ...this._selections });
+    const name =
+      ((this._nameInput?.node as HTMLInputElement | undefined)?.value ?? '').trim() ||
+      localStorage.getItem('kid-game-player-name') ||
+      'Player';
+    localStorage.setItem('kid-game-player-name', name);
+    this.scene.start('LivingRoomScene', { ...this._selections, playerName: name });
   }
 }

--- a/src/scenes/LivingRoomScene.ts
+++ b/src/scenes/LivingRoomScene.ts
@@ -27,19 +27,28 @@ interface CouchDimensions {
 
 export class LivingRoomScene extends Phaser.Scene {
   private _sel: Record<string, number> = {};
+  _playerName: string = 'Player';
   private _charG!: Phaser.GameObjects.Graphics;
   private _accG!: Phaser.GameObjects.Graphics;
   private _cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
   private _dpadState: Record<DPadDirection, boolean> = { up: false, down: false, left: false, right: false };
   private _dpadElements: Phaser.GameObjects.GameObject[] = [];
   private _dpadResizeTimer: ReturnType<typeof setTimeout> | null = null;
+  private _isMoving: boolean = false;
+  private _isSitting: boolean = true;
+  private _fgG!: Phaser.GameObjects.Graphics;
+  private _sKey!: Phaser.Input.Keyboard.Key;
 
   constructor() {
     super({ key: 'LivingRoomScene' });
   }
 
-  init(data: Record<string, number>): void {
+  init(data: Record<string, number> & { playerName?: string }): void {
     this._sel = data ?? {};
+    this._playerName =
+      data.playerName ??
+      localStorage.getItem('kid-game-player-name') ??
+      'Player';
   }
 
   create(): void {
@@ -51,12 +60,15 @@ export class LivingRoomScene extends Phaser.Scene {
     this._drawRoom(bgG, W, H);
 
     this._charG = this.add.graphics();
+    this._charG.setDepth(5);
     this._accG = this.add.graphics();
+    this._accG.setDepth(6);
     this._drawSittingCharacter(this._charG, this._accG, W, H);
 
-    // Draw couch front face on top so it partially overlaps the character's legs
-    const fgG = this.add.graphics();
-    this._drawCouchFront(fgG, W, H);
+    // Couch front overlaps character legs when sitting (depth > character); drops behind when standing
+    this._fgG = this.add.graphics();
+    this._drawCouchFront(this._fgG, W, H);
+    this._fgG.setDepth(8);
 
     // Scene title
     this.add
@@ -90,8 +102,12 @@ export class LivingRoomScene extends Phaser.Scene {
       this.scene.start('CharacterSelectScene');
     });
 
-    // Keyboard arrow keys
+    // Keyboard
     this._cursors = this.input.keyboard!.createCursorKeys();
+    this._sKey = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.S);
+
+    // Owl arrives 20 seconds after entering the scene
+    this.time.delayedCall(20000, this._spawnOwl, [], this);
 
     // D-pad touch state
     this._dpadState = { up: false, down: false, left: false, right: false };
@@ -130,7 +146,21 @@ export class LivingRoomScene extends Phaser.Scene {
     if (this._cursors.up.isDown    || this._dpadState.up)    dy -= speed;
     if (this._cursors.down.isDown  || this._dpadState.down)  dy += speed;
 
-    if (dx !== 0 || dy !== 0) {
+    const moving = dx !== 0 || dy !== 0;
+
+    // Stand up the first time the player moves
+    if (moving && this._isSitting) {
+      this._standUp();
+    }
+
+    // Press S while stationary to sit back down
+    if (!moving && !this._isSitting && Phaser.Input.Keyboard.JustDown(this._sKey)) {
+      this._sitDown();
+    }
+
+    this._isMoving = moving;
+
+    if (moving) {
       const W = this.scale.width;
       const H = this.scale.height;
       const maxDX = W * 0.4;
@@ -140,6 +170,30 @@ export class LivingRoomScene extends Phaser.Scene {
       this._accG.x  = this._charG.x;
       this._accG.y  = this._charG.y;
     }
+  }
+
+  private _standUp(): void {
+    this._isSitting = false;
+    const W = this.scale.width;
+    const H = this.scale.height;
+    this._charG.clear();
+    this._accG.clear();
+    this._drawStandingCharacter(this._charG, this._accG, W, H);
+    this._fgG.setDepth(2); // couch front behind character when standing
+  }
+
+  private _sitDown(): void {
+    this._isSitting = true;
+    this._charG.x = 0;
+    this._charG.y = 0;
+    this._accG.x  = 0;
+    this._accG.y  = 0;
+    const W = this.scale.width;
+    const H = this.scale.height;
+    this._charG.clear();
+    this._accG.clear();
+    this._drawSittingCharacter(this._charG, this._accG, W, H);
+    this._fgG.setDepth(8); // couch front in front of character legs when sitting
   }
 
   private _createDPad(W: number, H: number): void {
@@ -284,22 +338,39 @@ export class LivingRoomScene extends Phaser.Scene {
     g.fillRect(winCX - 3, winTop, 6, winH);
     g.fillRect(winCX - winW / 2, winTop + winH / 2 - 3, winW, 6);
 
-    // ── TV (left side of wall) ─────────────────────────────────────────────────
+    // ── TV on entertainment console (left side of wall) ───────────────────────
     const tvCX = Math.round(W * 0.18);
     const tvW = 140;
     const tvH = 88;
-    const tvTop = 85;
+    const consoleH = 38;
+    const consoleW = tvW + 40;
+    const consoleTop = floorY - consoleH;
+    const tvTop = consoleTop - tvH;
 
-    g.fillStyle(0x888888);
-    g.fillRect(tvCX - 4, tvTop + tvH + 8, 8, 26);
-    g.fillEllipse(tvCX, tvTop + tvH + 36, 36, 10);
+    // Entertainment console / TV stand
+    g.fillStyle(0x5a3c1e);
+    g.fillRect(tvCX - consoleW / 2, consoleTop, consoleW, consoleH);
+    // Console top edge highlight
+    g.fillStyle(0x7a5530);
+    g.fillRect(tvCX - consoleW / 2, consoleTop, consoleW, 5);
+    // Console doors
+    g.fillStyle(0x4a3010);
+    g.fillRect(tvCX - consoleW / 2 + 4, consoleTop + 8, consoleW / 2 - 8, consoleH - 13);
+    g.fillRect(tvCX + 4, consoleTop + 8, consoleW / 2 - 8, consoleH - 13);
+    // Door knobs
+    g.fillStyle(0xb8a060);
+    g.fillCircle(tvCX - 4, consoleTop + consoleH / 2, 3);
+    g.fillCircle(tvCX + 4, consoleTop + consoleH / 2, 3);
 
+    // TV bezel
     g.fillStyle(0x1c1c1c);
     g.fillRect(tvCX - tvW / 2 - 8, tvTop - 8, tvW + 16, tvH + 16);
 
+    // Screen
     g.fillStyle(0x0d1b2a);
     g.fillRect(tvCX - tvW / 2, tvTop, tvW, tvH);
 
+    // Screen shine
     g.fillStyle(0x1a3a5c);
     g.fillRect(tvCX - tvW / 2, tvTop, tvW / 2, tvH / 2);
 
@@ -343,7 +414,7 @@ export class LivingRoomScene extends Phaser.Scene {
 
   // ── Couch back (drawn before character) ──────────────────────────────────────
   private _drawCouchBack(g: Phaser.GameObjects.Graphics, W: number, H: number): void {
-    const { couchW, cx, armW, seatH, backH, seatY } = this._couchDimensions(W, H);
+    const { floorY, couchW, cx, armW, seatH, backH, seatY } = this._couchDimensions(W, H);
     const couchX = cx - couchW / 2;
 
     const couchMain  = 0x7b4f1e;
@@ -375,25 +446,24 @@ export class LivingRoomScene extends Phaser.Scene {
     g.fillStyle(couchLight);
     g.fillEllipse(couchX + armW / 2,          seatY - backH, armW + 6, 14);
     g.fillEllipse(couchX + couchW - armW / 2, seatY - backH, armW + 6, 14);
-  }
 
-  // ── Couch front face (drawn on top of character to show seat edge) ─────────
-  private _drawCouchFront(g: Phaser.GameObjects.Graphics, W: number, H: number): void {
-    const { floorY, couchW, cx, armW, seatH, seatY } = this._couchDimensions(W, H);
-    const couchX = cx - couchW / 2;
-
-    const couchDark = 0x5a380d;
-
-    g.fillStyle(couchDark);
-    g.fillRect(couchX + armW, seatY + seatH, couchW - armW * 2, 20);
-
+    // Arm front faces and couch legs live here (depth 0) so they never float over the character
     g.fillStyle(0x4a2d0d);
     g.fillRect(couchX,                 seatY + seatH, armW, 20);
     g.fillRect(couchX + couchW - armW, seatY + seatH, armW, 20);
-
     g.fillStyle(0x3e2408);
     g.fillRect(couchX + armW + 8,           floorY - 14, 14, 14);
     g.fillRect(couchX + couchW - armW - 22, floorY - 14, 14, 14);
+  }
+
+  // ── Couch seat-edge band (depth toggles: 8 sitting, 2 standing) ──────────
+  // Only this narrow strip belongs in front of the character when sitting.
+  // Arm fronts and couch legs were moved to _drawCouchBack (depth 0).
+  private _drawCouchFront(g: Phaser.GameObjects.Graphics, W: number, H: number): void {
+    const { couchW, cx, armW, seatH, seatY } = this._couchDimensions(W, H);
+    const couchX = cx - couchW / 2;
+    g.fillStyle(0x5a380d);
+    g.fillRect(couchX + armW, seatY + seatH, couchW - armW * 2, 20);
   }
 
   // ---------------------------------------------------------------------------
@@ -544,6 +614,397 @@ export class LivingRoomScene extends Phaser.Scene {
       ag.moveTo(cx + 29, headCY - 5);
       ag.lineTo(cx + 42, headCY - 3);
       ag.strokePath();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Owl + letter cinematic (Harry Potter intro)
+  // ---------------------------------------------------------------------------
+  private _spawnOwl(): void {
+    const W = this.scale.width;
+    const winCX = Math.round(W * 0.75);
+    const winTop = 60;
+    const winH = 110;
+
+    const owlG = this.add.graphics();
+    this._drawOwl(owlG);
+    owlG.setDepth(20);
+    owlG.x = W + 70;
+    owlG.y = winTop + winH / 2 - 10;
+
+    // Fly toward window
+    this.tweens.add({
+      targets: owlG,
+      x: winCX,
+      duration: 650,
+      ease: 'Power2',
+      onComplete: () => {
+        // Impact shake
+        this.cameras.main.shake(300, 0.009);
+
+        // Owl tumbles down and fades
+        this.tweens.add({
+          targets: owlG,
+          y: owlG.y + 80,
+          angle: 120,
+          alpha: 0,
+          duration: 450,
+          ease: 'Power2',
+          onComplete: () => owlG.destroy(),
+        });
+
+        // Letter slips through after a short delay
+        this.time.delayedCall(180, () => this._spawnLetter(winCX, winTop + 12));
+      },
+    });
+  }
+
+  private _spawnLetter(startX: number, startY: number): void {
+    const W = this.scale.width;
+    const H = this.scale.height;
+    const { seatY, cx } = this._couchDimensions(W, H);
+
+    // headCY matches _drawSittingCharacter: torsoTop = hipY-80, headCY = torsoTop-56
+    const headCY = seatY + 4 - 80 - 56; // seatY - 132
+    const lapY   = seatY - 40;           // hands/arms area
+
+    const letterG = this.add.graphics();
+    this._drawLetter(letterG);
+    letterG.x = startX;
+    letterG.y = startY;
+    letterG.setDepth(20);
+
+    // Phase 1 – float down to head
+    this.tweens.add({
+      targets: letterG,
+      x: cx,
+      y: headCY,
+      angle: 14,
+      duration: 2100,
+      ease: 'Sine.easeIn',
+      onComplete: () => {
+        // Phase 2 – bounce off head
+        this.tweens.add({
+          targets: letterG,
+          y: headCY - 28,
+          scaleX: 1.25,
+          scaleY: 1.25,
+          angle: -10,
+          duration: 130,
+          ease: 'Power2',
+          yoyo: true,
+          onComplete: () => {
+            // Phase 3 – fall into arms
+            this.tweens.add({
+              targets: letterG,
+              y: lapY,
+              angle: 6,
+              scaleX: 1,
+              scaleY: 1,
+              duration: 480,
+              ease: 'Bounce.easeOut',
+              onComplete: () => {
+                this.time.delayedCall(250, () => this._openLetter(letterG, cx, lapY, W, H));
+              },
+            });
+          },
+        });
+      },
+    });
+  }
+
+  private _openLetter(letterG: Phaser.GameObjects.Graphics, fromX: number, fromY: number, W: number, H: number): void {
+    const parchW = Math.min(W * 0.84, 560);
+    const parchH = Math.min(H * 0.84, 480);
+
+    // Fade out the small envelope
+    this.tweens.add({ targets: letterG, alpha: 0, duration: 180, onComplete: () => letterG.destroy() });
+
+    // Container grows from letter position to centre
+    const container = this.add.container(fromX, fromY);
+    container.setDepth(25);
+    container.setScale(0.06);
+
+    // Parchment background
+    const bg = this.add.graphics();
+    bg.fillStyle(0xf5e6c8);
+    bg.fillRoundedRect(-parchW / 2, -parchH / 2, parchW, parchH, 10);
+    bg.lineStyle(3, 0x8b7355);
+    bg.strokeRoundedRect(-parchW / 2, -parchH / 2, parchW, parchH, 10);
+    bg.lineStyle(1, 0xb8956a);
+    bg.strokeRoundedRect(-parchW / 2 + 8, -parchH / 2 + 8, parchW - 16, parchH - 16, 7);
+    // Wax seal at top
+    bg.fillStyle(0x6b0000);
+    bg.fillCircle(0, -parchH / 2 + 34, 22);
+    bg.fillStyle(0xaa2222);
+    bg.fillCircle(0, -parchH / 2 + 34, 15);
+    bg.fillStyle(0xdd3333);
+    bg.fillCircle(0, -parchH / 2 + 34, 9);
+    container.add(bg);
+
+    // Header
+    const headerY = -parchH / 2 + 78;
+    const header = this.add.text(0, headerY,
+      'HOGWARTS SCHOOL\nof Witchcraft & Wizardry', {
+        fontSize: '15px',
+        fontFamily: 'Georgia, "Times New Roman", serif',
+        color: '#3d1a00',
+        fontStyle: 'bold',
+        align: 'center',
+        lineSpacing: 3,
+      }).setOrigin(0.5).setAlpha(0);
+    container.add(header);
+
+    // Divider
+    const divG = this.add.graphics();
+    divG.lineStyle(1, 0x8b7355);
+    divG.beginPath();
+    divG.moveTo(-parchW / 2 + 40, headerY + 32);
+    divG.lineTo( parchW / 2 - 40, headerY + 32);
+    divG.strokePath();
+    container.add(divG);
+
+    // Letter body
+    const name = this._playerName || 'Student';
+    const bodyText =
+      `Dear Mrs. ${name},\n\n` +
+      `We are pleased to inform you that you have been accepted at ` +
+      `Hogwarts School of Witchcraft and Wizardry. Please find enclosed ` +
+      `a list of all necessary books and equipment.\n` +
+      `Term begins on September 1. We await your owl by no later than July 31.\n\n` +
+      `Yours sincerely,\n\n` +
+      `Minerva McGonagall,\n` +
+      `Deputy Headmistress`;
+
+    const fontSize = Math.max(10, Math.round(parchW / 50));
+    const body = this.add.text(
+      -parchW / 2 + 36,
+      headerY + 44,
+      bodyText,
+      {
+        fontSize: `${fontSize}px`,
+        fontFamily: 'Georgia, "Times New Roman", serif',
+        color: '#2d1200',
+        lineSpacing: 5,
+        wordWrap: { width: parchW - 72 },
+      }
+    ).setOrigin(0, 0).setAlpha(0);
+    container.add(body);
+
+    // Close button
+    const closeBtn = this.add.text(parchW / 2 - 22, -parchH / 2 + 18, 'x', {
+      fontSize: '20px',
+      fontFamily: 'Arial',
+      color: '#5a2a00',
+      fontStyle: 'bold',
+    }).setOrigin(0.5).setAlpha(0).setInteractive({ useHandCursor: true });
+    closeBtn.on('pointerover', () => closeBtn.setColor('#cc0000'));
+    closeBtn.on('pointerout',  () => closeBtn.setColor('#5a2a00'));
+    closeBtn.on('pointerdown', () => {
+      this.tweens.add({
+        targets: container,
+        scaleX: 0.06, scaleY: 0.06, alpha: 0,
+        duration: 220,
+        onComplete: () => container.destroy(),
+      });
+    });
+    container.add(closeBtn);
+
+    // Grow from letter position to centre
+    this.tweens.add({
+      targets: container,
+      x: W / 2, y: H / 2,
+      scaleX: 1, scaleY: 1,
+      duration: 460,
+      ease: 'Back.easeOut',
+      onComplete: () => {
+        this.tweens.add({
+          targets: [header, body, closeBtn],
+          alpha: 1,
+          duration: 300,
+        });
+      },
+    });
+  }
+
+  private _drawOwl(g: Phaser.GameObjects.Graphics): void {
+    // Body
+    g.fillStyle(0x8b6914);
+    g.fillEllipse(0, 12, 32, 46);
+
+    // Head
+    g.fillStyle(0x8b6914);
+    g.fillCircle(0, -16, 17);
+
+    // Ear tufts
+    g.fillStyle(0x5a3e08);
+    g.fillTriangle(-8, -28, -3, -40, 0, -28);
+    g.fillTriangle(8, -28, 3, -40, 0, -28);
+
+    // Chest
+    g.fillStyle(0xd4a020);
+    g.fillEllipse(0, 16, 18, 28);
+
+    // Wings
+    g.fillStyle(0x6a4a0a);
+    g.fillEllipse(-20, 10, 14, 34);
+    g.fillEllipse(20, 10, 14, 34);
+
+    // Eyes
+    g.fillStyle(0xffcc00);
+    g.fillCircle(-7, -18, 7);
+    g.fillCircle(7, -18, 7);
+    g.fillStyle(0x000000);
+    g.fillCircle(-7, -18, 4);
+    g.fillCircle(7, -18, 4);
+    g.fillStyle(0xffffff);
+    g.fillCircle(-5, -20, 2);
+    g.fillCircle(9, -20, 2);
+
+    // Beak
+    g.fillStyle(0xe8a000);
+    g.fillTriangle(-4, -12, 4, -12, 0, -6);
+
+    // Talons
+    g.fillStyle(0xe8a000);
+    g.fillEllipse(-7, 35, 9, 6);
+    g.fillEllipse(7, 35, 9, 6);
+  }
+
+  private _drawLetter(g: Phaser.GameObjects.Graphics): void {
+    // Envelope body
+    g.fillStyle(0xf5e6c8);
+    g.fillRect(-16, -12, 32, 24);
+    g.lineStyle(1, 0x8b7355);
+    g.strokeRect(-16, -12, 32, 24);
+
+    // Envelope flap crease
+    g.lineStyle(1, 0xbba070);
+    g.beginPath();
+    g.moveTo(-16, -12);
+    g.lineTo(0, 2);
+    g.lineTo(16, -12);
+    g.strokePath();
+
+    // Wax seal
+    g.fillStyle(0x8b0000);
+    g.fillCircle(0, 4, 5);
+    g.fillStyle(0xcc2200);
+    g.fillCircle(0, 4, 3);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Standing character – drawn when the player is moving
+  // ---------------------------------------------------------------------------
+  private _drawStandingCharacter(g: Phaser.GameObjects.Graphics, ag: Phaser.GameObjects.Graphics, W: number, H: number): void {
+    const { floorY, cx } = this._couchDimensions(W, H);
+    const sel = this._sel;
+
+    const hairStyleOpt = TRAITS[0].options[sel['hairStyle'] ?? 0];
+    const hairColor    = HAIR_COLORS[TRAITS[1].options[sel['hairColor'] ?? 0]];
+    const skinColor    = SKIN_TONES[TRAITS[2].options[sel['skinTone'] ?? 0]];
+    const eyeColor     = EYE_COLORS[TRAITS[3].options[sel['eyeColor'] ?? 0]];
+    const topOpt       = TRAITS[4].options[sel['top'] ?? 0];
+    const topColor     = TOP_COLORS[TRAITS[5].options[sel['topColor'] ?? 0]];
+    const bottomOpt    = TRAITS[6].options[sel['bottom'] ?? 0];
+    const bottomColor  = BOTTOM_COLORS[bottomOpt];
+    const accessoryOpt = TRAITS[7].options[sel['accessory'] ?? 0];
+
+    const baseY = floorY;
+
+    // Shoes
+    g.fillStyle(0x333333);
+    g.fillEllipse(cx - 22, baseY, 30, 12);
+    g.fillEllipse(cx + 22, baseY, 30, 12);
+
+    // Legs / bottom
+    g.fillStyle(bottomColor);
+    if (bottomOpt === 'Shorts') {
+      g.fillRect(cx - 24, baseY - 120, 22, 40);
+      g.fillRect(cx + 2,  baseY - 120, 22, 40);
+      g.fillStyle(skinColor);
+      g.fillRect(cx - 24, baseY - 80, 22, 80);
+      g.fillRect(cx + 2,  baseY - 80, 22, 80);
+    } else if (bottomOpt === 'Skirt') {
+      g.fillTriangle(cx - 28, baseY - 120, cx + 28, baseY - 120, cx - 38, baseY - 5);
+      g.fillTriangle(cx - 28, baseY - 120, cx + 28, baseY - 120, cx + 38, baseY - 5);
+    } else {
+      g.fillRect(cx - 24, baseY - 130, 22, 130);
+      g.fillRect(cx + 2,  baseY - 130, 22, 130);
+    }
+
+    // Torso
+    g.fillStyle(topColor);
+    if (topOpt === 'Dress') {
+      g.fillRect(cx - 28, baseY - 200, 56, 120);
+      g.fillTriangle(cx - 28, baseY - 80, cx + 28, baseY - 80, cx - 42, baseY - 5);
+      g.fillTriangle(cx - 28, baseY - 80, cx + 28, baseY - 80, cx + 42, baseY - 5);
+    } else {
+      g.fillRect(cx - 28, baseY - 200, 56, 80);
+    }
+    if (topOpt === 'Hoodie') {
+      g.fillStyle(Phaser.Display.Color.ValueToColor(topColor).darken(20).color);
+      g.fillRect(cx - 4, baseY - 200, 8, 60);
+    } else if (topOpt === 'Jacket') {
+      g.fillStyle(Phaser.Display.Color.ValueToColor(topColor).darken(30).color);
+      g.fillRect(cx - 28, baseY - 200, 10, 80);
+      g.fillRect(cx + 18, baseY - 200, 10, 80);
+    }
+
+    // Arms
+    g.fillStyle(topColor);
+    g.fillRect(cx - 44, baseY - 195, 18, 60);
+    g.fillRect(cx + 26, baseY - 195, 18, 60);
+    g.fillStyle(skinColor);
+    g.fillEllipse(cx - 35, baseY - 135, 18, 20);
+    g.fillEllipse(cx + 35, baseY - 135, 18, 20);
+
+    // Neck
+    g.fillStyle(skinColor);
+    g.fillRect(cx - 10, baseY - 220, 20, 20);
+
+    // Head
+    g.fillStyle(skinColor);
+    g.fillEllipse(cx, baseY - 265, 80, 90);
+
+    // Eyes
+    g.fillStyle(0xffffff);
+    g.fillEllipse(cx - 18, baseY - 270, 20, 14);
+    g.fillEllipse(cx + 18, baseY - 270, 20, 14);
+    g.fillStyle(eyeColor);
+    g.fillCircle(cx - 18, baseY - 270, 6);
+    g.fillCircle(cx + 18, baseY - 270, 6);
+    g.fillStyle(0x000000);
+    g.fillCircle(cx - 18, baseY - 270, 3);
+    g.fillCircle(cx + 18, baseY - 270, 3);
+
+    // Mouth
+    g.fillStyle(0xcc5555);
+    g.fillEllipse(cx, baseY - 250, 22, 10);
+
+    // Nose
+    const noseDark = Phaser.Display.Color.ValueToColor(skinColor).darken(15).color;
+    g.fillStyle(noseDark);
+    g.fillTriangle(cx - 5, baseY - 258, cx + 5, baseY - 258, cx, baseY - 248);
+
+    // Hair
+    this._drawHair(g, hairStyleOpt, cx, baseY, hairColor);
+
+    // Accessories
+    if (accessoryOpt === 'Hat' || accessoryOpt === 'Hat + Glasses') {
+      ag.fillStyle(0x5a3a1a);
+      ag.fillEllipse(cx, baseY - 310, 96, 18);
+      ag.fillRect(cx - 36, baseY - 350, 72, 42);
+      ag.fillStyle(0x331a00);
+      ag.fillRect(cx - 36, baseY - 318, 72, 8);
+    }
+    if (accessoryOpt === 'Glasses' || accessoryOpt === 'Hat + Glasses') {
+      ag.lineStyle(3, 0x333333);
+      ag.strokeCircle(cx - 18, baseY - 270, 11);
+      ag.strokeCircle(cx + 18, baseY - 270, 11);
+      ag.beginPath(); ag.moveTo(cx - 7, baseY - 270); ag.lineTo(cx + 7, baseY - 270); ag.strokePath();
+      ag.beginPath(); ag.moveTo(cx - 29, baseY - 270); ag.lineTo(cx - 42, baseY - 268); ag.strokePath();
+      ag.beginPath(); ag.moveTo(cx + 29, baseY - 270); ag.lineTo(cx + 42, baseY - 268); ag.strokePath();
     }
   }
 


### PR DESCRIPTION
## Summary

- **Player name bar** — HTML input at the top of the character select screen, persisted in localStorage and carried into the game as playerName.
- **Harry Potter owl cinematic** — 20 seconds after entering the living room, an owl flies in from the right and smashes the window (camera shake). A Hogwarts letter drifts down, bounces off the character's head, falls into their arms, then expands into a full parchment acceptance letter with the player's name substituted in. Closeable with an x button.
- **Standing / sitting toggle** — moving stands the character up; they stay standing until S is pressed while stationary.
- **Z-index fixes** — couch arm fronts and legs moved to depth-0 background; only the seat-edge band is depth-8 (in front of character when sitting). Standing always puts character in front of all couch parts.
- **TV on entertainment console** — repositioned from floating wall art to a floor-level wooden console.
- **CLAUDE.md** updated with Harry Potter theme direction, z-depth table, and new controls.
- **.claude/launch.json** added with dev and preview server configs.

## Test plan

- [ ] Name input shows at top of character select, persists on reload
- [ ] Start Game transitions correctly with playerName set
- [ ] Moving stands character up; S key sits them back down
- [ ] Couch parts do not float in front of character in either pose
- [ ] TV appears on floor console
- [ ] After 20s owl cinematic fires, letter bounces off head into arms, opens with correct name
- [ ] Closing the letter with x dismisses it cleanly

Generated with [Claude Code](https://claude.com/claude-code)